### PR TITLE
Feature/6 connect with empty carries page

### DIFF
--- a/wrapping/wrappinggallery/static/wrappinggallery/index.js
+++ b/wrapping/wrappinggallery/static/wrappinggallery/index.js
@@ -192,14 +192,6 @@ function updateCarryGallery(carries) {
 }
 
 document.addEventListener('DOMContentLoaded', function() { 
-    // Set link of navbar brand
-    const navbarBrand = document.querySelector('.navbar-brand');
-    const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
-    carriesTab.classList.add('active');
-    
-    const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
-    aboutTab.classList.remove('active');
-
     // Set initial active buttons in filters
     initialiseFiltersData();
 

--- a/wrapping/wrappinggallery/static/wrappinggallery/index.js
+++ b/wrapping/wrappinggallery/static/wrappinggallery/index.js
@@ -22,35 +22,6 @@ function handleInputChange() {
     }
 }
 
-function showPage(tab) {
-    // Clear active tab
-    const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
-    carriesTab.classList.remove('active');
-
-    const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
-    aboutTab.classList.remove('active');
-
-    // Hide all of the divs:
-    const carriesPage = document.getElementById('carries-page');
-    carriesPage.style.display = 'none';
-
-    const aboutPage = document.getElementById('about-page');
-    aboutPage.style.display = 'none';
-
-    // Show the div provided in the argument
-    const selectedPage = document.getElementById(tab.dataset.page);
-    selectedPage.style.display = 'block';
-
-    // Mark tab as active
-    tab.classList.add('active');
-
-    // Reset filters correctly
-    if (tab.dataset.page === 'carries-page') {
-        initialiseFiltersData();
-    }
-}
-
-
 function updateFilterData(button) {
     const property = button.parentElement.getAttribute('data-property');
     const value = button.getAttribute('data-value');
@@ -157,6 +128,7 @@ function updateCarryGallery(carries) {
     // Get imageGrid div
     const gridContainer = document.getElementById('imageGrid');
     gridContainer.innerHTML = '';
+    const baseUrlPattern = gridContainer.dataset.baseUrlPattern.replace('PLACEHOLDER', '');
 
     carries.forEach(carry => {
         // Create grid item
@@ -169,7 +141,24 @@ function updateCarryGallery(carries) {
         // Create image
         const img = document.createElement('img');
         img.src = imageUrl; // Combine the static URL with the file name
-        img.alt = carry.coverpicture;
+        img.alt = carry.name;
+        
+        // Create on click functionality
+        img.addEventListener('click', function() {
+            // Construct the full URL by appending the name to the base URL pattern
+            const url = `${baseUrlPattern}${carry.name}`;
+            
+            // Clear active tab
+            const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
+            carriesTab.classList.remove('active');
+
+            const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
+            aboutTab.classList.remove('active');
+
+            // Redirect to the constructed URL
+            window.location.href = url;
+
+        });
 
         // Create description container
         const descContainer = document.createElement('div');
@@ -202,17 +191,18 @@ function updateCarryGallery(carries) {
     })
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function() { 
+    // Set link of navbar brand
+    const navbarBrand = document.querySelector('.navbar-brand');
+    const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
+    carriesTab.classList.add('active');
+    
+    const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
+    aboutTab.classList.remove('active');
+
     // Set initial active buttons in filters
     initialiseFiltersData();
 
     // Filter carries in gallery
-    filterCarries();
-
-    // Set link of navbar brand
-    const navbarBrand = document.querySelector('.navbar-brand');
-    const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
-    navbarBrand.onclick = function() {
-        showPage(carriesTab);
-    };
+    filterCarries();   
 });

--- a/wrapping/wrappinggallery/templates/wrappinggallery/about.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/about.html
@@ -5,15 +5,4 @@
 {% block body %}
 <h1> ABOUT</h1>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function() { 
-        // Set link of navbar brand
-        const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
-        carriesTab.classList.remove('active');
-        
-        const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
-        aboutTab.classList.add('active'); 
-    }); 
-</script>
-
 {% endblock %}

--- a/wrapping/wrappinggallery/templates/wrappinggallery/about.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/about.html
@@ -1,0 +1,19 @@
+{% extends "wrappinggallery/layout.html" %}
+
+{% load static %}
+
+{% block body %}
+<h1> ABOUT</h1>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() { 
+        // Set link of navbar brand
+        const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
+        carriesTab.classList.remove('active');
+        
+        const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
+        aboutTab.classList.add('active'); 
+    }); 
+</script>
+
+{% endblock %}

--- a/wrapping/wrappinggallery/templates/wrappinggallery/carry.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/carry.html
@@ -1,0 +1,20 @@
+{% extends "wrappinggallery/layout.html" %}
+
+{% load static %}
+
+{% block body %}
+<h1> hello {{name}}</h1>
+<h2> position {{position}}</h2>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() { 
+        // Set link of navbar brand
+        const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
+        carriesTab.classList.remove('active');
+        
+        const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
+        aboutTab.classList.remove('active'); 
+    }); 
+</script>
+
+{% endblock %}

--- a/wrapping/wrappinggallery/templates/wrappinggallery/carry.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/carry.html
@@ -6,15 +6,4 @@
 <h1> hello {{name}}</h1>
 <h2> position {{position}}</h2>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function() { 
-        // Set link of navbar brand
-        const carriesTab = document.querySelector('.nav-link[data-page="carries-page"]');
-        carriesTab.classList.remove('active');
-        
-        const aboutTab = document.querySelector('.nav-link[data-page="about-page"]');
-        aboutTab.classList.remove('active'); 
-    }); 
-</script>
-
 {% endblock %}

--- a/wrapping/wrappinggallery/templates/wrappinggallery/index.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/index.html
@@ -3,40 +3,35 @@
 {% load static %}
 
 {% block body %}
-<div id="about-page" style="display: none;">
-    <p>HELLO</p>
-</div>
-<div id="carries-page">
-    <div class="content-container">
-        <div class="row justify-content-center">
-            <div class="col-md-6">
-                <div class="input-group mb-3">
-                    <input id="search-input" type="text" class="form-control input-underline" placeholder="Search carries" oninput="handleInputChange()">
-                    <button id="button-filter" class="btn btn-outline-secondary ml-4" type="button" onclick="toggleFilterBox()" >Filters</button>
-                </div>
+<div class="content-container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="input-group mb-3">
+                <input id="search-input" type="text" class="form-control input-underline" placeholder="Search carries" oninput="handleInputChange()">
+                <button id="button-filter" class="btn btn-outline-secondary ml-4" type="button" onclick="toggleFilterBox()" >Filters</button>
             </div>
-        </div>
-
-        <div id=filterBox style="display: none;">
-            <p><strong> Position </strong></p>
-            <div id="positionFilters" data-property="position">
-                {% for value in position_values %}
-                    <button type="button" class="btn btn-custom mx-1" data-property="position" data-value="{{ value }}" onclick="clickFilterButton(this)">{{ value }}</button>
-                {% endfor %}
-            </div>
-            <hr>
-            <p><strong> Size </strong> (referenced to the base size)</p>
-            <div id="sizeFilters" data-property="size">
-                {% for value in size_values %}
-                    <button type="button" class="btn btn-custom mx-1" data-property="size" data-value="{{ value }}" onclick="clickFilterButton(this)">{{ value }}</button>
-                {% endfor %}
-            </div>
-            <hr>
         </div>
     </div>
-    <div class="grid" id="imageGrid"></div>
-</div>
 
-<script src="{% static 'wrappinggallery/app.js' %}"></script>
+    <div id=filterBox style="display: none;">
+        <p><strong> Position </strong></p>
+        <div id="positionFilters" data-property="position">
+            {% for value in position_values %}
+                <button type="button" class="btn btn-custom mx-1" data-property="position" data-value="{{ value }}" onclick="clickFilterButton(this)">{{ value }}</button>
+            {% endfor %}
+        </div>
+        <hr>
+        <p><strong> Size </strong> (referenced to the base size)</p>
+        <div id="sizeFilters" data-property="size">
+            {% for value in size_values %}
+                <button type="button" class="btn btn-custom mx-1" data-property="size" data-value="{{ value }}" onclick="clickFilterButton(this)">{{ value }}</button>
+            {% endfor %}
+        </div>
+        <hr>
+    </div>
+</div>
+<div class="grid" id="imageGrid" data-base-url-pattern="{% url 'carry' 'PLACEHOLDER' %}"></div>
+
+<script src="{% static 'wrappinggallery/index.js' %}"></script>
 
 {% endblock %}

--- a/wrapping/wrappinggallery/templates/wrappinggallery/layout.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/layout.html
@@ -24,10 +24,10 @@
         <div class="collapse navbar-collapse" id="navbarNavDropdown">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                    <a class="nav-link" data-page="about-page" href="{% url 'about' %}">About Me</a>
+                    <a class="nav-link {% if request.path == '/about/' %}active{% endif %}" data-page="about-page" href="{% url 'about' %}">About Me</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-page="carries-page" href="{% url 'index' %}">Carries</a>
+                    <a class="nav-link {% if request.path == '/' %}active{% endif %}" data-page="carries-page" href="{% url 'index' %}">Carries</a>
                 </li>
             </ul>
         </div>

--- a/wrapping/wrappinggallery/templates/wrappinggallery/layout.html
+++ b/wrapping/wrappinggallery/templates/wrappinggallery/layout.html
@@ -24,10 +24,10 @@
         <div class="collapse navbar-collapse" id="navbarNavDropdown">
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                    <a class="nav-link {% if tab == 'about' %}active{% endif %}" data-page="about-page" onclick="showPage(this)">About Me</a>
+                    <a class="nav-link" data-page="about-page" href="{% url 'about' %}">About Me</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link {% if tab == 'carries' or not tab %}active{% endif %}" data-page="carries-page" onclick="showPage(this)">Carries</a>
+                    <a class="nav-link" data-page="carries-page" href="{% url 'index' %}">Carries</a>
                 </li>
             </ul>
         </div>

--- a/wrapping/wrappinggallery/urls.py
+++ b/wrapping/wrappinggallery/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("about/", views.about, name="about"),
     path("api/filter-carries/", views.filter_carries, name="filter_carries"),
+    path("carry/<str:name>", views.carry, name="carry"),
 ]

--- a/wrapping/wrappinggallery/urls.py
+++ b/wrapping/wrappinggallery/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("about/", views.about, name="about"),
     path("api/filter-carries/", views.filter_carries, name="filter_carries"),
 ]

--- a/wrapping/wrappinggallery/views.py
+++ b/wrapping/wrappinggallery/views.py
@@ -14,6 +14,10 @@ def index(request):
         "position_values": ["Any", "Front", "Back"]
     })
 
+
+def about(request):
+    return render(request, "wrappinggallery/about.html")
+
 @require_GET
 def filter_carries(request):
     # Extract lists of properties and values from GET parameters

--- a/wrapping/wrappinggallery/views.py
+++ b/wrapping/wrappinggallery/views.py
@@ -18,6 +18,18 @@ def index(request):
 def about(request):
     return render(request, "wrappinggallery/about.html")
 
+
+def carry(request, name):
+    # Initialize a queryset for filtering
+    queryset = Carry.objects.all()
+    queryset = queryset.filter(name=name)
+    results = list(queryset.values('name', 'position', 'title', 'size', 'coverpicture'))
+
+    assert len(results) == 1
+    
+    return render(request, "wrappinggallery/carry.html", results[0])
+
+
 @require_GET
 def filter_carries(request):
     # Extract lists of properties and values from GET parameters
@@ -37,5 +49,5 @@ def filter_carries(request):
             queryset = queryset.filter(title__icontains=val)
 
     # Serialize the results
-    results = list(queryset.values('position', 'title', 'size', 'coverpicture'))
+    results = list(queryset.values('name', 'position', 'title', 'size', 'coverpicture'))
     return JsonResponse({'carries': results})


### PR DESCRIPTION
Create a carry page in a separate URL "carry/<string>". This view uses information about the carry queried from the database inside its corresponding function "carry" in views.py.

It reuses the navbar but it has dummy content.

The single page functionality has been removed from now to simplify navigation and ensure URLs are descriptive. Now every page (about, carries or an individual carry) are reloaded completely every time user clicks on a tab in the navbar. The navigation is controlled through hrefs in the navbar and the active tab is controlled reading the request path. No javascript required.