### PR TITLE
103 allow loading csv data to database

### DIFF
--- a/wrapping/Makefile
+++ b/wrapping/Makefile
@@ -77,3 +77,6 @@ sync-prod-db:
 
 test:
 	$(PYTHON) manage.py test
+
+load-csv-data:
+	$(PYTHON) manage.py load_csv_data initial_data.csv --settings=wrapping.settings.development

--- a/wrapping/initial_data.csv
+++ b/wrapping/initial_data.csv
@@ -1,0 +1,2 @@
+name,title,size,shoulders,layers,mmposition,videotutorial,videoauthor,position,description,pretied,finish,coverpicture,newborns,legstraighteners,leaners,bigkids,feeding,quickups,difficulty,fancy,votes
+blublublu,Annye's Front Wrap Cross Carry,0,2,2,-1,https://www.youtube.com/embed/E-k0Nkp416g?si=CdDsAv0CE4oiKHI,Sheen Slings,front,,False,knotless,annes_fwcc.png,1,1,1,1,1,1,5,1,0

--- a/wrapping/wrappinggallery/management/commands/load_csv_data.py
+++ b/wrapping/wrappinggallery/management/commands/load_csv_data.py
@@ -1,0 +1,101 @@
+import csv
+import json
+import os
+from wrappinggallery.models import Carry, Ratings
+from django.core.management.base import BaseCommand
+from django.core.exceptions import ValidationError
+
+class Command(BaseCommand):
+    help = 'Load carries from CSV file to db'
+
+    def add_arguments(self, parser):
+        parser.add_argument('csv_file', type=str, help='The input CSV file')
+
+    def handle(self, *args, **kwargs):
+        uploaded = 0
+
+        csv_file = kwargs['csv_file']
+
+        # Check the file exists
+        if not os.path.exists(csv_file):
+            raise ValidationError(f'{csv_file} does not exist')
+        
+        with open(csv_file, 'r') as f:
+            reader = csv.DictReader(f)
+            data = list(reader)
+        
+            for row in data:
+                # Check that this carry doesn't already exist, if so, skip
+                result = Carry.objects.filter(name=row["name"])
+
+                if result.count() == 0:
+                    carry = Carry.objects.update_or_create(
+                        name=row["name"],
+                        title=row["title"],
+                        size=row["size"],
+                        shoulders=row["shoulders"],
+                        layers=row["layers"],
+                        mmposition=row["mmposition"],
+                        videotutorial=row["videotutorial"],
+                        videoauthor=row["videoauthor"],
+                        position=row["position"],
+                        description=row["description"],
+                        pretied=row["pretied"],
+                        finish=row["finish"],
+                        coverpicture=row["coverpicture"],
+                    )
+
+                    ratings = Ratings.objects.update_or_create(
+                        carry=carry,
+                        legstraighteners=row["legstraighteners"],
+                        leaners=row["leaners"],
+                        bigkids=row["bigkids"],
+                        feeding=row["feeding"],
+                        quickups=row["quickups"],
+                        difficulty=row["difficulty"],
+                        fancy=row["fancy"],
+                        votes=row["votes"],
+                    )
+
+                    uploaded += 1
+                    carry.save()
+                    ratings.save()
+
+                    print(f"- Created {row["name"]}.")
+                else:
+                    carry = result[0]
+
+                    update = input(f"Do you want to update {row['name']}? ([y]/n): ").strip().lower()
+                    if update in ["y", ""]:
+                        carry.title = row["title"]
+                        carry.size = row["size"]
+                        carry.shoulders = row["shoulders"]
+                        carry.layers = row["layers"]
+                        carry.mmposition = row["mmposition"]
+                        carry.videotutorial = row["videotutorial"]
+                        carry.videoauthor = row["videoauthor"]
+                        carry.position = row["position"]
+                        carry.description = row["description"]
+                        carry.pretied = row["pretied"]
+                        carry.finish = row["finish"]
+                        carry.coverpicture = row["coverpicture"]
+
+                        ratings = Ratings.objects.get(carry__name=row["name"])
+                        ratings.legstraighteners = row["legstraighteners"]
+                        ratings.leaners = row["leaners"]
+                        ratings.bigkids = row["bigkids"]
+                        ratings.feeding = row["feeding"]
+                        ratings.quickups = row["quickups"]
+                        ratings.difficulty = row["difficulty"]
+                        ratings.fancy = row["fancy"]
+                        ratings.votes = row["votes"]
+
+                        uploaded += 1
+                        carry.save()
+                        ratings.save()
+
+                        self.stdout.write(self.style.SUCCESS(f"- Updated {row['name']}."))
+                    else:
+                        self.stdout.write(self.style.NOTICE(f"- Skipped updating {row['name']}."))
+        
+        self.stdout.write(self.style.SUCCESS(f'\nSuccessfully loaded or updated {uploaded} carries to database.'))


### PR DESCRIPTION
Created a command in `wrapping/management/commands` called load `load_csv_data` to load CSV data from a file passed as an argument to the database. The file must contain one column for each field in Carry and Ratings. If any of the carries we try to add already exists user will be asked if they want to override it. If it doesn't exist, it will be added.

It can be run like this:
```
python manage.py load_csv_data initial_data.csv --settings=wrapping.settings.development
```

or if we don't want to change the settings and are happy with the filename initial_data.csv, it can be run with:

```
make load-csv-data
```