### PR TITLE
Remove deprecated Django setting

### DIFF
--- a/wrapping/wrapping/settings/production.py
+++ b/wrapping/wrapping/settings/production.py
@@ -56,7 +56,11 @@ CSRF_TRUSTED_ORIGINS = config("CSRF_TRUSTED_ORIGINS", default="").split(",")
 
 # Adds a unique hash at the end of static files names when running collectstatic
 # It ensures that old static files aren't cached and get reloaded when they change
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases


### PR DESCRIPTION
Deprecated Django setting was preventing the hashing of static files.